### PR TITLE
Add depends_on for ecs_service in the autoscaling target. The resourc…

### DIFF
--- a/terraform/amazon/auto-scaling.tf
+++ b/terraform/amazon/auto-scaling.tf
@@ -5,6 +5,7 @@ resource "aws_appautoscaling_target" "target" {
   scalable_dimension = "ecs:service:DesiredCount"
   min_capacity       = "${var.autoscaling_min_capacity}"
   max_capacity       = "${var.autoscaling_max_capacity}"
+  depends_on = ["aws_ecs_service.web", "aws_ecs_service.worker"]
 }
 
 # Scale capacity up by one


### PR DESCRIPTION
…e fails if the service is not up already