### PR TITLE
Update SCPlanner Legacy

### DIFF
--- a/terraform/amazon/auto-scaling.tf
+++ b/terraform/amazon/auto-scaling.tf
@@ -1,19 +1,22 @@
 resource "aws_appautoscaling_target" "target" {
-  count = "${var.autoscaling_enabled == "true" ? 1 : 0}"
+  count              = var.autoscaling_enabled == "true" ? 1 : 0
   service_namespace  = "ecs"
   resource_id        = "service/${var.cluster_name}/${var.logical_name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = "${var.autoscaling_min_capacity}"
-  max_capacity       = "${var.autoscaling_max_capacity}"
-  depends_on = ["aws_ecs_service.web", "aws_ecs_service.worker"]
+  min_capacity       = var.autoscaling_min_capacity
+  max_capacity       = var.autoscaling_max_capacity
+  depends_on = [
+    aws_ecs_service.web,
+    aws_ecs_service.worker
+  ]
 }
 
 # Scale capacity up by one
 resource "aws_appautoscaling_policy" "up" {
-  count = "${var.autoscaling_enabled == "true" ? 1 : 0}"
+  count              = var.autoscaling_enabled == "true" ? 1 : 0
   name               = "${var.logical_name}-ecs-scale-up"
   service_namespace  = "ecs"
-  resource_id        = "${aws_appautoscaling_target.target.resource_id}"
+  resource_id        = aws_appautoscaling_target.target[0].resource_id
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
@@ -27,15 +30,17 @@ resource "aws_appautoscaling_policy" "up" {
     }
   }
 
-  depends_on = ["aws_appautoscaling_target.target"]
+  depends_on = [
+    aws_appautoscaling_target.target
+  ]
 }
 
 # Scale capacity down by one
 resource "aws_appautoscaling_policy" "down" {
-  count = "${var.autoscaling_enabled == "true" ? 1 : 0}"
+  count              = var.autoscaling_enabled == "true" ? 1 : 0
   name               = "${var.logical_name}-ecs-scale-down"
   service_namespace  = "ecs"
-  resource_id        = "${aws_appautoscaling_target.target.resource_id}"
+  resource_id        = aws_appautoscaling_target.target[0].resource_id
   scalable_dimension = "ecs:service:DesiredCount"
 
   step_scaling_policy_configuration {
@@ -49,87 +54,105 @@ resource "aws_appautoscaling_policy" "down" {
     }
   }
 
-  depends_on = ["aws_appautoscaling_target.target"]
+  depends_on = [
+    aws_appautoscaling_target.target
+  ]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_metric_alarm_rpm_high" {
-  count               = "${var.autoscaling_enabled == "true" && var.autoscaling_resource_type == "cpu" ? 1 : 0}"
-  alarm_name          = "${var.logical_name}-CPUUtilization-High"
-  alarm_description   = "Managed by Terraform"
-  alarm_actions       = ["${aws_appautoscaling_policy.up.arn}"]
-  # ok_actions          = ["${var.alarm_pagerduty_sns}"]
+  count             = var.autoscaling_enabled == "true" && var.autoscaling_resource_type == "cpu" ? 1 : 0
+  alarm_name        = "${var.logical_name}-CPUUtilization-High"
+  alarm_description = "Managed by Terraform"
+  alarm_actions = [
+    aws_appautoscaling_policy.up[0].arn
+  ]
+  # ok_actions = [
+  #   var.alarm_pagerduty_sns
+  # ]
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "${var.autoscaling_alarm_evaluation_periods}"
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
-  period              = "${var.autoscaling_alarm_period}"
-  statistic           = "${var.autoscaling_alarm_statistic}"
-  threshold           = "${var.autoscaling_alarm_threshold_high}"
-  datapoints_to_alarm = "${var.autoscaling_datapoints_to_alarm}"
+  period              = var.autoscaling_alarm_period
+  statistic           = var.autoscaling_alarm_statistic
+  threshold           = var.autoscaling_alarm_threshold_high
+  datapoints_to_alarm = var.autoscaling_datapoints_to_alarm
 
   dimensions {
-    ClusterName = "${var.cluster_name}"
-    ServiceName = "${var.logical_name}"
+    ClusterName = var.cluster_name
+    ServiceName = var.logical_name
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_metric_alarm_rpm_low" {
-  count               = "${var.autoscaling_enabled == "true" && var.autoscaling_resource_type == "cpu" ? 1 : 0}"
-  alarm_name          = "${var.logical_name}-CPUUtilization-Low"
-  alarm_description   = "Managed by Terraform"
-  alarm_actions       = ["${aws_appautoscaling_policy.down.arn}"]
-  # ok_actions          = ["${var.alarm_pagerduty_sns}"]
+  count             = var.autoscaling_enabled == "true" && var.autoscaling_resource_type == "cpu" ? 1 : 0
+  alarm_name        = "${var.logical_name}-CPUUtilization-Low"
+  alarm_description = "Managed by Terraform"
+  alarm_actions = [
+    aws_appautoscaling_policy.down[0].arn
+  ]
+  # ok_actions = [
+  #   var.alarm_pagerduty_sns
+  # ]
   comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "${var.autoscaling_alarm_evaluation_periods}"
+  evaluation_periods  = var.autoscaling_alarm_evaluation_periods
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
-  period              = "${var.autoscaling_alarm_period}"
-  statistic           = "${var.autoscaling_alarm_statistic}"
-  threshold           = "${var.autoscaling_alarm_threshold_low}"
-  datapoints_to_alarm = "${var.autoscaling_datapoints_to_alarm}"
+  period              = var.autoscaling_alarm_period
+  statistic           = var.autoscaling_alarm_statistic
+  threshold           = var.autoscaling_alarm_threshold_low
+  datapoints_to_alarm = var.autoscaling_datapoints_to_alarm
 
   dimensions {
-    ClusterName = "${var.cluster_name}"
-    ServiceName = "${var.logical_name}"
+    ClusterName = var.cluster_name
+    ServiceName = var.logical_name
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_metric_alarm_queue_age_high" {
-  count               = "${var.autoscaling_enabled == "true" && var.autoscaling_resource_type == "queue" ? 1 : 0}"
-  alarm_name          = "${var.logical_name}-ApproximateAgeOfOldestMessage-High"
-  alarm_description   = "Managed by Terraform"
-  alarm_actions       = ["${aws_appautoscaling_policy.up.arn}"]
-  # ok_actions          = ["${var.alarm_pagerduty_sns}"]
+  count             = var.autoscaling_enabled == "true" && var.autoscaling_resource_type == "queue" ? 1 : 0
+  alarm_name        = "${var.logical_name}-ApproximateAgeOfOldestMessage-High"
+  alarm_description = "Managed by Terraform"
+  alarm_actions = [
+    aws_appautoscaling_policy.up[0].arn
+  ]
+  # ok_actions = [
+  #   var.alarm_pagerduty_sns
+  # ]
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "${var.autoscaling_alarm_evaluation_periods}"
+  evaluation_periods  = var.autoscaling_alarm_evaluation_periods
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
-  period              = "${var.autoscaling_alarm_period}"
-  statistic           = "${var.autoscaling_alarm_statistic}"
-  threshold           = "${var.autoscaling_alarm_threshold_high}"
-  datapoints_to_alarm = "${var.autoscaling_datapoints_to_alarm}"
+  period              = var.autoscaling_alarm_period
+  statistic           = var.autoscaling_alarm_statistic
+  threshold           = var.autoscaling_alarm_threshold_high
+  datapoints_to_alarm = var.autoscaling_datapoints_to_alarm
 
   dimensions {
-    QueueName = "${var.autoscaling_queue_name}"
+    QueueName = var.autoscaling_queue_name
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_metric_alarm_queue_age_low" {
-  count               = "${var.autoscaling_enabled == "true" && var.autoscaling_resource_type == "queue" ? 1 : 0}"
-  alarm_name          = "${var.logical_name}-ApproximateAgeOfOldestMessage-Low"
-  alarm_description   = "Managed by Terraform"
-  alarm_actions       = ["${aws_appautoscaling_policy.down.arn}"]
-  # ok_actions          = ["${var.alarm_pagerduty_sns}"]
+  count             = var.autoscaling_enabled == "true" && var.autoscaling_resource_type == "queue" ? 1 : 0
+  alarm_name        = "${var.logical_name}-ApproximateAgeOfOldestMessage-Low"
+  alarm_description = "Managed by Terraform"
+  alarm_actions = [
+    aws_appautoscaling_policy.down[0].arn
+  ]
+  # ok_actions = [
+  #   var.alarm_pagerduty_sns
+  # ]
   comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "${var.autoscaling_alarm_evaluation_periods}"
+  evaluation_periods  = var.autoscaling_alarm_evaluation_periods
   metric_name         = "ApproximateAgeOfOldestMessage"
   namespace           = "AWS/SQS"
-  period              = "${var.autoscaling_alarm_period}"
-  statistic           = "${var.autoscaling_alarm_statistic}"
-  threshold           = "${var.autoscaling_alarm_threshold_low}"
-  datapoints_to_alarm = "${var.autoscaling_datapoints_to_alarm}"
+  period              = var.autoscaling_alarm_period
+  statistic           = var.autoscaling_alarm_statistic
+  threshold           = var.autoscaling_alarm_threshold_low
+  datapoints_to_alarm = var.autoscaling_datapoints_to_alarm
 
   dimensions {
-    QueueName = "${var.autoscaling_queue_name}"
+    QueueName = var.autoscaling_queue_name
   }
 }

--- a/terraform/amazon/data.tf
+++ b/terraform/amazon/data.tf
@@ -1,38 +1,39 @@
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
 
 data "aws_vpc" "default" {
   default = true
 }
 
 data "aws_subnet_ids" "default" {
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id = data.aws_vpc.default.id
 }
 
 data "aws_subnet" "default" {
-  count = "${length(data.aws_subnet_ids.default.ids)}"
-  id    = "${data.aws_subnet_ids.default.ids[count.index]}"
+  for_each = data.aws_subnet_ids.default.ids
+  id       = each.value
 }
 
 data "aws_ecs_cluster" "main" {
-  cluster_name = "${var.cluster_name}"
+  cluster_name = var.cluster_name
 }
 
 data "aws_iam_role" "task_container_role" {
-  name = "${var.ecs_task_container_role}"
+  name = var.ecs_task_container_role
 }
 
 data "aws_iam_role" "task_execution_role" {
-  name = "${var.ecs_task_execution_role}"
+  name = var.ecs_task_execution_role
 }
 
 data "aws_ecr_repository" "main" {
-  name = "${var.logical_name}"
+  name = var.logical_name
 }
 
 data "aws_route53_zone" "selected" {
-  name         = "${local.aws_route53_zone_name}"
+  name = local.aws_route53_zone_name
 }
 
 data "aws_acm_certificate" "main" {
-  domain = "${local.domain_name}"
+  domain = local.domain_name
 }

--- a/terraform/amazon/ecs.tf
+++ b/terraform/amazon/ecs.tf
@@ -1,12 +1,13 @@
 resource "aws_ecs_task_definition" "main" {
-  family = "${var.logical_name}"
-  network_mode = "awsvpc"
+  family             = var.logical_name
+  network_mode       = "awsvpc"
+  cpu                = var.cpu
+  memory             = var.memory
+  task_role_arn      = data.aws_iam_role.task_container_role.arn
+  execution_role_arn = data.aws_iam_role.task_execution_role.arn
   requires_compatibilities = [
-    "FARGATE"]
-  cpu = "${var.cpu}"
-  memory = "${var.memory}"
-  task_role_arn = "${data.aws_iam_role.task_container_role.arn}"
-  execution_role_arn = "${data.aws_iam_role.task_execution_role.arn}"
+    "FARGATE"
+  ]
 
   container_definitions = <<DEFINITION
 [
@@ -42,54 +43,58 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "web" {
-  count = "${var.is_worker ? 0 : 1}" # no load balancer if worker
-  name = "${var.logical_name}"
-  cluster = "${data.aws_ecs_cluster.main.id}"
-  task_definition = "${aws_ecs_task_definition.main.arn}"
-  desired_count = "${var.container_count}"
-  launch_type = "FARGATE"
-  health_check_grace_period_seconds = 120
+  count           = var.is_worker ? 0 : 1 # no load balancer if worker
+  name            = var.logical_name
+  cluster         = data.aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.main.arn
+  desired_count   = var.container_count
+  launch_type     = "FARGATE"
+
+  health_check_grace_period_seconds  = 120
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent = "${var.max_healthy_percent}"
+  deployment_maximum_percent         = var.max_healthy_percent
 
   network_configuration {
     security_groups = [
-      "${aws_security_group.ecs_tasks.id}"]
-    subnets = [
-      "${data.aws_subnet.default.*.id}"]
+      aws_security_group.ecs_tasks.id
+    ]
+    subnets          = data.aws_subnet_ids.default.ids
     assign_public_ip = true
   }
 
   load_balancer {
-    target_group_arn = "${aws_alb_target_group.app.id}"
-    container_name = "${var.logical_name}"
-    container_port = "${var.port}"
+    target_group_arn = aws_alb_target_group.app.id
+    container_name   = var.logical_name
+    container_port   = var.port
   }
 
   depends_on = [
-    "aws_alb_listener.https"
+    aws_alb_listener.https
   ]
 }
 
 resource "aws_ecs_service" "worker" {
-  count = "${var.is_worker ? 1 : 0}" # no load balancer if worker
-  name = "${var.logical_name}"
-  cluster = "${data.aws_ecs_cluster.main.id}"
-  task_definition = "${aws_ecs_task_definition.main.arn}"
-  desired_count = "${var.container_count}"
-  launch_type = "FARGATE"
+  count           = var.is_worker ? 1 : 0 # no load balancer if worker
+  name            = var.logical_name
+  cluster         = data.aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.main.arn
+  desired_count   = var.container_count
+  launch_type     = "FARGATE"
+
   deployment_minimum_healthy_percent = 100
-  deployment_maximum_percent = "${var.max_healthy_percent}"
+  deployment_maximum_percent         = var.max_healthy_percent
 
   lifecycle {
-    ignore_changes = ["desired_count"]
+    ignore_changes = [
+      desired_count
+    ]
   }
 
   network_configuration {
     security_groups = [
-      "${aws_security_group.ecs_tasks.id}"]
-    subnets = [
-      "${data.aws_subnet.default.*.id}"]
+      aws_security_group.ecs_tasks.id
+    ]
+    subnets          = data.aws_subnet_ids.default.ids
     assign_public_ip = true
   }
 }

--- a/terraform/amazon/locals.tf
+++ b/terraform/amazon/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  domain_name = "${var.domain_name != "default" ? var.domain_name : var.env == "production" ? "repostnetwork.com" : "repostnetworktesting.com"}"
-  aws_route53_zone_name = "${local.domain_name}."
+  domain_name             = var.domain_name != "default" ? var.domain_name : var.env == "production" ? "repostnetwork.com" : "repostnetworktesting.com"
+  aws_route53_zone_name   = "${local.domain_name}."
   aws_route53_record_name = "${var.logical_name}.services.${local.domain_name}"
 }

--- a/terraform/amazon/route53.tf
+++ b/terraform/amazon/route53.tf
@@ -1,8 +1,10 @@
 resource "aws_route53_record" "main" {
-  count = "${var.is_worker ? 0 : 1}" # no cname if worker
-  zone_id = "${data.aws_route53_zone.selected.zone_id}"
-  name    = "${local.aws_route53_record_name}"
+  count   = var.is_worker ? 0 : 1 # no cname if worker
+  zone_id = data.aws_route53_zone.selected.zone_id
+  name    = local.aws_route53_record_name
   type    = "CNAME"
   ttl     = "300"
-  records = ["${aws_alb.main.dns_name}"]
+  records = [
+    aws_alb.main.dns_name
+  ]
 }

--- a/terraform/amazon/security-groups.tf
+++ b/terraform/amazon/security-groups.tf
@@ -1,30 +1,30 @@
 resource "aws_security_group" "lb" {
-  name = "${var.logical_name}-lb"
+  name        = "${var.logical_name}-lb"
   description = "controls access to the ALB"
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id      = data.aws_vpc.default.id
 
   ingress {
-    protocol = "tcp"
+    protocol  = "tcp"
     from_port = 443
-    to_port = 443
+    to_port   = 443
     cidr_blocks = [
       "0.0.0.0/0"
     ]
   }
 
   ingress {
-    protocol = "tcp"
+    protocol  = "tcp"
     from_port = 443
-    to_port = 443
+    to_port   = 443
     ipv6_cidr_blocks = [
       "::/0"
     ]
   }
 
   ingress {
-    protocol = "tcp"
+    protocol  = "tcp"
     from_port = 80
-    to_port = 80
+    to_port   = 80
     cidr_blocks = [
       "0.0.0.0/0"
     ]
@@ -32,8 +32,8 @@ resource "aws_security_group" "lb" {
 
   egress {
     from_port = 0
-    to_port = 0
-    protocol = "-1"
+    to_port   = 0
+    protocol  = "-1"
     cidr_blocks = [
       "0.0.0.0/0"
     ]
@@ -42,23 +42,25 @@ resource "aws_security_group" "lb" {
 
 # Traffic to the ECS Cluster should only come from the ALB
 resource "aws_security_group" "ecs_tasks" {
-  name = "${var.logical_name}"
+  name        = var.logical_name
   description = "allow inbound access from the ALB only"
-  vpc_id = "${data.aws_vpc.default.id}"
+  vpc_id      = data.aws_vpc.default.id
 
   ingress {
-    protocol = "tcp"
-    from_port = "${var.port}"
-    to_port = "${var.port}"
+    protocol  = "tcp"
+    from_port = var.port
+    to_port   = var.port
     security_groups = [
-      "${aws_security_group.lb.id}"]
+      aws_security_group.lb.id
+    ]
   }
 
   egress {
-    protocol = "-1"
+    protocol  = "-1"
     from_port = 0
-    to_port = 0
+    to_port   = 0
     cidr_blocks = [
-      "0.0.0.0/0"]
+      "0.0.0.0/0"
+    ]
   }
 }

--- a/terraform/amazon/vars.tf
+++ b/terraform/amazon/vars.tf
@@ -2,13 +2,13 @@ variable "region" {
   default = "us-east-1"
 }
 
-variable logical_name {
+variable "logical_name" {
   description = "The base name to use for all aws resources."
 }
 
 variable "port" {
   description = "Port exposed by the docker image to redirect traffic to"
-  default = "8080"
+  default     = "8080"
 }
 
 variable "container_count" {
@@ -44,7 +44,7 @@ variable "ecs_task_execution_role" {
 
 variable "ecr_path" {
   description = "Path of ECR containing all images"
-  default = "ecr_path"
+  default     = "ecr_path"
 }
 
 variable "github_repository" {
@@ -65,7 +65,7 @@ variable "health_check_endpoint" {
 
 variable "is_worker" {
   description = "Boolean: True if this ecs task is a worker. False otherwise."
-  default = false
+  default     = false
 }
 
 variable "autoscaling_enabled" {
@@ -122,14 +122,13 @@ variable "idle_timeout" {
 }
 
 provider "aws" {
-  version = ">= 1.47.0"
   profile = "default"
-  region = "${var.region}"
+  region  = var.region
 }
 
 terraform {
   backend "s3" {
     encrypt = true
-    region = "us-east-1"
+    region  = "us-east-1"
   }
 }

--- a/terraform/amazon/versions.tf
+++ b/terraform/amazon/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      version = "~> 3.57.0"
+    }
+  }
+}


### PR DESCRIPTION
## Update SCPlanner Legacy

* Update Terraform to `0.13`
* Update AWS provider to `3.57.*`

### Description

SCPlanner ECS deployment broke last night. They moved from AWS provider `2.70.0` to `3.57.0`.

I looked at previous commits on `master` branch to update Terraform to `0.13` as few warning were shown during ECS deployment.

### References

* Working action : https://github.com/repostnetwork/scplanner-java/runs/3544063478
* Failing action : https://github.com/repostnetwork/scplanner-java/runs/3556064186